### PR TITLE
[Kadena] Split into multiple transactions when asset number is high

### DIFF
--- a/apps/oracle/src/api.ts
+++ b/apps/oracle/src/api.ts
@@ -37,7 +37,7 @@ export async function getAssetPrices(assets: Asset[]) {
 async function getAssetQuotation(network: string, address: string) {
   const url = `${config.api.http.url}/${network}/${address}`;
   const data = await axios.get(url);
-  return Quotation.parse(data).Price;
+  return Quotation.parse(data.data).Price;
 }
 
 type FeedSelection = {

--- a/apps/oracle/src/config.ts
+++ b/apps/oracle/src/config.ts
@@ -64,6 +64,7 @@ export default {
     contract: process.env.KADENA_CONTRACT || 'free.dia-oracle',
     networkId: process.env.KADENA_NETWORK_ID || 'testnet04',
     chainId: process.env.KADENA_CHAIN_ID || '0',
+    maxAssetsPerTx: parseInt(process.env.KADENA_MAX_ASSETS_PER_TX || '10', 10),
   },
 
   chainName: process.env.CHAIN_NAME as ChainName || ChainName.SOROBAN,

--- a/apps/oracle/src/oracles/kadena.ts
+++ b/apps/oracle/src/oracles/kadena.ts
@@ -2,6 +2,7 @@ import { Pact, createClient, createSignWithKeypair } from '@kadena/client';
 import { IKeyPair, ChainId } from '@kadena/types';
 import { submitKadenaTx } from '@repo/common';
 import config from '../config';
+import { splitIntoFixedBatches } from '../utils'
 
 const keyPair: IKeyPair = {
   publicKey: config.kadena.publicKey,
@@ -18,19 +19,25 @@ export async function updateOracle(keys: string[], prices: number[]) {
 
   const isoDate = `${(new Date()).toISOString().split('.')[0]}Z`
   const dates = prices.map(() => isoDate);
-  const formattedString = "[" + dates.map(date => `(time "${date}")`).join(", ") + "]";
-  const unsignedTransaction = Pact.builder
-  .execution(
-    `(${config.kadena.contract}.set-multiple-values ${JSON.stringify(keys)} ${formattedString} ${JSON.stringify(prices)})`,
-    )
-    .addSigner(keyPair.publicKey)
-    .setMeta({ chainId: config.kadena.chainId as ChainId, senderAccount: `k:${keyPair.publicKey}` })
-    .setNetworkId(config.kadena.networkId)
-    .createTransaction();
+  
+  const keysBatches = splitIntoFixedBatches(keys, config.kadena.maxAssetsPerTx);
+  const datesBatches = splitIntoFixedBatches(dates, config.kadena.maxAssetsPerTx);
+  const pricesBatches = splitIntoFixedBatches(prices, config.kadena.maxAssetsPerTx);
+  
+  for (let i = 0; i < keysBatches.length; i++) {
+    const formattedString = "[" + datesBatches[i].map(date => `(time "${date}")`).join(", ") + "]";
+    const unsignedTransaction = Pact.builder
+      .execution(
+        `(${config.kadena.contract}.set-multiple-values ${JSON.stringify(keysBatches[i])} ${formattedString} ${JSON.stringify(pricesBatches[i])})`,
+        )
+        .addSigner(keyPair.publicKey)
+        .setMeta({ chainId: config.kadena.chainId as ChainId, senderAccount: `k:${keyPair.publicKey}` })
+        .setNetworkId(config.kadena.networkId)
+        .createTransaction();
 
-  console.log('Unsigned transaction:', unsignedTransaction);
-  const signedTx = await signWithKeypair(unsignedTransaction);
-  console.log('Signed transaction:', signedTx);
-  await submitKadenaTx(client, signedTx);
+    const signedTx = await signWithKeypair(unsignedTransaction);
+    console.log('Signed transaction:', signedTx);
+    await submitKadenaTx(client, signedTx);
+  }
   console.log('Oracle updated');
 }

--- a/apps/oracle/src/utils.ts
+++ b/apps/oracle/src/utils.ts
@@ -1,0 +1,7 @@
+export const splitIntoFixedBatches = <T>(items: T[], batchSize: number): T[][] => {
+  let batches: T[][] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+      batches.push(items.slice(i, i + batchSize));
+  }
+  return batches;
+}


### PR DESCRIPTION
This feature splits kadena transaction into multiple ones, if asset number is more than allowed limit for one tx. This limitation is set by `maxAssetsPerTx` key in the kadena's config. By default its equal to `10`